### PR TITLE
Fix (Workaround) for closing session before action is executed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+.vs
 .idea
 .venv
 venv

--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ These cameras typically use the **Peer-to-Peer protocol** for communication, and
 
 ## Tested camera prefixes
 
-- DGOK*
+| Prefix   | Protocol | Video | [Audio<sup>*</sup>](https://github.com/devbis/aiopppp/issues/6) | PTZ | White Light | IR Light | Reboot |
+|:---------|:---------|:-----:|:---------------------------------------------------------------:|:---:|:-----------:|:--------:|:------:|
+| **DGOK** | 📜 JSON  | ✅   | ✖️                                                             | ✅  | ✅          | ✅      | ✅     |
+| **PTZA** | 🔢 Binary| ✅   | ✖️                                                             | ✅  | ✅          | 🚫      | ❌     |
+| **FTYC** | 🔢 Binary| [❌<sup>*</sup>](https://github.com/devbis/aiopppp/issues/8)| ✖️      | 🚫  | 🚫          | ✅      | ❌     |
+| [**BATE**<sup>*</sup>](https://github.com/devbis/pppp_camera/issues/4) | 🔢 Binary|❔ |✖️    | ❔   | ❔           | ❔       | ❔     |
+| [**DGB**<sup>*</sup>](https://github.com/devbis/pppp_camera/issues/2) | 📜 JSON   |⚠️ |✖️   | ❔   | ❔           | ❔       | ❔     |
+| [**ACCQ**<sup>*</sup>](https://github.com/devbis/pppp_camera/issues/1) | ❔ Unknown|✖️|✖️    | ✖️  | ✖️          | ✖️      | ✖️     |
+
+**Legend:**
+- &nbsp;✅&nbsp; **Working**: Feature is fully functional.
+- &thinsp;⚠️&thinsp;**Partially working**: Feature works with limitations or issues.
+- &nbsp;❌&nbsp; **Not working**: Feature is implemented but does not function.
+- &nbsp;✖️&nbsp; **Not implemented**: Feature is not implemented in the system.
+- &nbsp;🚫&nbsp; **Not supported**: Feature is not supported by the device.
+- &ensp;❔ &nbsp; **Not tested**: Feature has not been tested on the device.
 
 ## Installation
 

--- a/custom_components/pppp_camera/device.py
+++ b/custom_components/pppp_camera/device.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 
 import aiopppp
@@ -73,6 +74,7 @@ class PPPPDevice:
 
         self._connected_num -= 1
         if self._connected_num == 0:
+            await asyncio.sleep(1);
             await self.device.close()
 
     async def async_setup(self) -> None:


### PR DESCRIPTION
#5 Maybe there is better way to wait for sending commands to camera before closing connection, but that works for me.